### PR TITLE
test: extend coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tamir</groupId>
     <artifactId>text-based-calculator</artifactId>
-    <version>0.0.9</version>
+    <version>0.0.10</version>
 
     <properties>
         <maven.compiler.target>11</maven.compiler.target>

--- a/src/main/java/tamir/parser/AbstractSyntaxTreeParser.java
+++ b/src/main/java/tamir/parser/AbstractSyntaxTreeParser.java
@@ -83,7 +83,7 @@ public class AbstractSyntaxTreeParser {
 				expressions.push(new PostDecrementAstNode(getVariableNameOfPostUnaryOperatorToken(token)));
 			else if (isBinaryOperator(token)) {
 				BinaryOperator binaryOperator = BinaryOperator.fromToken(token);
-				createExpressionsFromBinaryOperatorsWithEqualOrHigherPrecedence(binaryOperator);
+				createExpressionsFromBinaryOperatorsWithHigherPrecedence(binaryOperator);
 				binaryOperators.push(binaryOperator);
 			} else throw new InvalidAbstractSyntaxTreeStructureException(binaryOperators, expressions, token);
 		}
@@ -107,14 +107,14 @@ public class AbstractSyntaxTreeParser {
 			}
 		}
 
-		private void createExpressionsFromBinaryOperatorsWithEqualOrHigherPrecedence(BinaryOperator binaryOperator) {
-			while (!binaryOperators.isEmpty() && isOperatorOfLowerPrecedenceThanTopOperator(binaryOperator)) {
+		private void createExpressionsFromBinaryOperatorsWithHigherPrecedence(BinaryOperator binaryOperator) {
+			while (!binaryOperators.isEmpty() && isOperatorOfLowerOrEqualPrecedenceThanTopOperator(binaryOperator)) {
 				expressions.push(popBinaryOperatorAstNode());
 			}
 		}
 
-		private boolean isOperatorOfLowerPrecedenceThanTopOperator(BinaryOperator binaryOperator) {
-			return binaryOperator.getPrecedence() < binaryOperators.peek().getPrecedence();
+		private boolean isOperatorOfLowerOrEqualPrecedenceThanTopOperator(BinaryOperator binaryOperator) {
+			return binaryOperator.getPrecedence() <= binaryOperators.peek().getPrecedence();
 		}
 
 		private AbstractSyntaxTreeNode getValueExpression() {

--- a/src/main/java/tamir/parser/operator/BinaryOperator.java
+++ b/src/main/java/tamir/parser/operator/BinaryOperator.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -40,7 +39,7 @@ public enum BinaryOperator {
 	private static final Map<String, BinaryOperator> TOKEN_TO_OPERATOR = createTokenToOperatorMap();
 
 	private static Set<String> getAllBinaryOperatorTokens() {
-		return Stream.of(ADDITION, SUBTRACTION, MULTIPLICATION, DIVISION)
+		return Arrays.stream(BinaryOperator.values())
 				.map(BinaryOperator::getToken)
 				.collect(toSet());
 	}

--- a/src/test/java/tamir/calculator/CalculatorContextTest.java
+++ b/src/test/java/tamir/calculator/CalculatorContextTest.java
@@ -6,8 +6,7 @@ import tamir.exception.UnknownVariableException;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CalculatorContextTest {
 
@@ -21,15 +20,17 @@ class CalculatorContextTest {
 
 	@Test
 	void whenPutNewVariableToContext_thenVariableWasAdded() {
+		assertFalse(context.getVariableToValue().containsKey("x"));
 		context.put("x", 1);
 		assertEquals(1, context.get("x"));
 	}
 
 	@Test
 	void whenPutValueToExistingVariable_thenVariableValueHasBeenUpdated() {
-		assertEquals(10, context.get("count"));
-		context.put("count", 4);
-		assertEquals(4, context.get("count"));
+		int countValueBeforeChange = context.get("count");
+		int updatedValue = countValueBeforeChange + 1;
+		context.put("count", updatedValue);
+		assertEquals(updatedValue, context.get("count"));
 	}
 
 	@Test
@@ -39,9 +40,24 @@ class CalculatorContextTest {
 
 	@Test
 	void whenAlteringVariableToValueMap_thenContextNotBeingChanged() {
-		assertEquals(10, context.get("count"));
+		int countValueBeforeChange = context.get("count");
 		Map<String, Integer> variableToValue = context.getVariableToValue();
-		variableToValue.put("count", 1);
-		assertEquals(10, context.get("count"));
+		variableToValue.put("count", countValueBeforeChange + 1);
+		assertEquals(countValueBeforeChange, context.get("count"));
+	}
+
+	@Test
+	void testVariableNameIsCaseSensitive() {
+		assertEquals(1, context.getVariableToValue().size());
+		String lowercaseVariableName = context.getVariableToValue().keySet().iterator().next();
+		int lowercaseVariableValue = context.get(lowercaseVariableName);
+		String uppercaseVariableName = lowercaseVariableName.toUpperCase();
+		int uppercaseVariableValue = lowercaseVariableValue + 1;
+		assertNotEquals(lowercaseVariableValue, uppercaseVariableValue);
+		context.put(uppercaseVariableName, uppercaseVariableValue);
+
+		Map<String, Integer> expectedVariableToValueAfterChange = Map.of(lowercaseVariableName, lowercaseVariableValue,
+				uppercaseVariableName, uppercaseVariableValue);
+		assertEquals(expectedVariableToValueAfterChange, context.getVariableToValue());
 	}
 }

--- a/src/test/java/tamir/calculator/TextBasedCalculatorTest.java
+++ b/src/test/java/tamir/calculator/TextBasedCalculatorTest.java
@@ -35,4 +35,15 @@ class TextBasedCalculatorTest {
 	void whenUsingUnknownVariable_thenThrowsUnknownVariableException() {
 		assertThrows(UnknownVariableException.class, () -> runTextBasedCalculator(new Scanner("x = unknown\n\n")));
 	}
+
+	@Test
+	void whenEachExpressionSetsNewVariable_thenNumVariablesEqualsNumExpressions() {
+		String input = String.join("\n",
+				"a = 1",
+				"b = 2",
+				"c = 3",
+				"\n");
+		Map<String, Integer> variableToValue = runTextBasedCalculator(new Scanner(input));
+		assertEquals(3, variableToValue.size());
+	}
 }

--- a/src/test/java/tamir/parser/AbstractSyntaxTreeParserTest.java
+++ b/src/test/java/tamir/parser/AbstractSyntaxTreeParserTest.java
@@ -6,6 +6,7 @@ import tamir.parser.assignment.*;
 import tamir.parser.ast.AdditionAstNode;
 import tamir.parser.ast.IntegerAstNode;
 import tamir.parser.ast.MultiplicationAstNode;
+import tamir.parser.ast.SubtractionAstNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -94,15 +95,23 @@ class AbstractSyntaxTreeParserTest {
 	@Test
 	void whenOperatorIsMissingAnOperand_thenParseExpressionThrowsInvalidAbstractSyntaxTreeStructureException() {
 		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
+				() -> parseExpressionIntoAbstractSyntaxTree("x = *"));
+		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
 				() -> parseExpressionIntoAbstractSyntaxTree("x = 1 +"));
 		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
 				() -> parseExpressionIntoAbstractSyntaxTree("x = 1 * 2 / "));
+	}
+
+	@Test
+	void whenValueExpressionContainsMultipleOperandsWithoutOperator_thenParseExpressionThrowsInvalidAbstractSyntaxTreeStructureException() {
 		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
 				() -> parseExpressionIntoAbstractSyntaxTree("item += x y"));
 		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
 				() -> parseExpressionIntoAbstractSyntaxTree("x = 1 t 2"));
 		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
 				() -> parseExpressionIntoAbstractSyntaxTree("x = a 1 t"));
+		assertThrows(InvalidAbstractSyntaxTreeStructureException.class,
+				() -> parseExpressionIntoAbstractSyntaxTree("x = 1 1 1"));
 	}
 
 	@Test
@@ -113,5 +122,15 @@ class AbstractSyntaxTreeParserTest {
 		AssignmentRootNode expectedRootNode = new AssignmentRootNode("x", valueExpression);
 
 		assertEquals(expectedRootNode, parseExpressionIntoAbstractSyntaxTree("x = 1 + 2 * 3"));
+	}
+
+	@Test
+	void whenExpressionContainsOperatorsWithSamePrecedence_thenParseExpressionFromLeftToRight() {
+		SubtractionAstNode left = new SubtractionAstNode(new IntegerAstNode(1), new IntegerAstNode(2));
+		IntegerAstNode right = new IntegerAstNode(3);
+		SubtractionAstNode valueExpression = new SubtractionAstNode(left, right);
+		AssignmentRootNode expectedRootNode = new AssignmentRootNode("x", valueExpression);
+
+		assertEquals(expectedRootNode, parseExpressionIntoAbstractSyntaxTree("x = 1 - 2 - 3"));
 	}
 }

--- a/src/test/java/tamir/parser/ExpressionTokenizerTest.java
+++ b/src/test/java/tamir/parser/ExpressionTokenizerTest.java
@@ -48,7 +48,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenStartsWithLetterAndContainsLetterAndOrDigits_thenIsVariableReturnTrue() {
+	void whenTokenStartsWithLetterAndContainsLettersAndOrDigits_thenIsVariableReturnTrue() {
 		assertTrue(isVariable("x"));
 		assertTrue(isVariable("x1"));
 		assertTrue(isVariable("xyz"));
@@ -104,7 +104,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenStartsWithDoublePlusAndContainsValidVariable_thenIsPreIncrementReturnsTrue() {
+	void whenTokenStartsWithDoublePlusAndContainsValidVariableName_thenIsPreIncrementReturnsTrue() {
 		assertTrue(isPreIncrement("++x"));
 		assertTrue(isPreIncrement("++a"));
 		assertTrue(isPreIncrement("++item"));
@@ -112,7 +112,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenStartsWithDoublePlusButDoesNotContainValidVariable_thenIsPreIncrementReturnsFalse() {
+	void whenTokenStartsWithDoublePlusButDoesNotContainValidVariableName_thenIsPreIncrementReturnsFalse() {
 		assertFalse(isPreIncrement("++"));
 		assertFalse(isPreIncrement("+++"));
 		assertFalse(isPreIncrement("++1"));
@@ -127,7 +127,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenEndsWithDoublePlusAndContainsValidVariable_thenIsPostIncrementReturnsTrue() {
+	void whenTokenEndsWithDoublePlusAndContainsValidVariableName_thenIsPostIncrementReturnsTrue() {
 		assertTrue(isPostIncrement("x++"));
 		assertTrue(isPostIncrement("a++"));
 		assertTrue(isPostIncrement("item++"));
@@ -135,7 +135,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenEndsWithDoublePlusButDoesNotContainValidVariable_thenIsPostIncrementReturnsFalse() {
+	void whenTokenEndsWithDoublePlusButDoesNotContainValidVariableName_thenIsPostIncrementReturnsFalse() {
 		assertFalse(isPostIncrement("++"));
 		assertFalse(isPostIncrement("+++"));
 		assertFalse(isPostIncrement("1++"));
@@ -150,7 +150,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenStartsWithDoubleMinusAndContainsValidVariable_thenIsPreDecrementReturnsTrue() {
+	void whenTokenStartsWithDoubleMinusAndContainsValidVariableName_thenIsPreDecrementReturnsTrue() {
 		assertTrue(isPreDecrement("--x"));
 		assertTrue(isPreDecrement("--a"));
 		assertTrue(isPreDecrement("--item"));
@@ -158,7 +158,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenStartsWithDoubleMinusButDoesNotContainValidVariable_thenIsPreDecrementReturnsFalse() {
+	void whenTokenStartsWithDoubleMinusButDoesNotContainValidVariableName_thenIsPreDecrementReturnsFalse() {
 		assertFalse(isPreDecrement("--"));
 		assertFalse(isPreDecrement("---"));
 		assertFalse(isPreDecrement("--1"));
@@ -173,7 +173,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenEndsWithDoubleMinusAndContainsValidVariable_thenIsPostDecrementReturnsTrue() {
+	void whenTokenEndsWithDoubleMinusAndContainsValidVariableName_thenIsPostDecrementReturnsTrue() {
 		assertTrue(isPostDecrement("x--"));
 		assertTrue(isPostDecrement("a--"));
 		assertTrue(isPostDecrement("item--"));
@@ -181,7 +181,7 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenTokenEndsWithDoubleMinusButDoesNotContainValidVariable_thenIsPostDecrementReturnsFalse() {
+	void whenTokenEndsWithDoubleMinusButDoesNotContainValidVariableName_thenIsPostDecrementReturnsFalse() {
 		assertFalse(isPostDecrement("--"));
 		assertFalse(isPostDecrement("---"));
 		assertFalse(isPostDecrement("1--"));
@@ -196,18 +196,20 @@ class ExpressionTokenizerTest {
 	}
 
 	@Test
-	void whenPreUnaryOperatorContainsValidVariable_thenGetVariableNameOfPreUnaryOperatorTokenReturnsVariableName() {
+	void whenPreUnaryOperatorContainsValidVariableName_thenGetVariableNameOfPreUnaryOperatorTokenReturnsVariableName() {
 		assertEquals("x", getVariableNameOfPreUnaryOperatorToken("++x"));
 		assertEquals("x", getVariableNameOfPreUnaryOperatorToken("--x"));
 		assertEquals("abc", getVariableNameOfPreUnaryOperatorToken("--abc"));
 		assertEquals("item", getVariableNameOfPreUnaryOperatorToken("++item"));
+		assertEquals("a1", getVariableNameOfPreUnaryOperatorToken("++a1"));
 	}
 
 	@Test
-	void whenPostUnaryOperatorContainsValidVariable_thenGetVariableNameOfPostUnaryOperatorTokenReturnsVariableName() {
+	void whenPostUnaryOperatorContainsValidVariableName_thenGetVariableNameOfPostUnaryOperatorTokenReturnsVariableName() {
 		assertEquals("x", getVariableNameOfPostUnaryOperatorToken("x++"));
 		assertEquals("x", getVariableNameOfPostUnaryOperatorToken("x--"));
 		assertEquals("abc", getVariableNameOfPostUnaryOperatorToken("abc--"));
 		assertEquals("item", getVariableNameOfPostUnaryOperatorToken("item++"));
+		assertEquals("a1", getVariableNameOfPostUnaryOperatorToken("a1++"));
 	}
 }

--- a/src/test/java/tamir/parser/assignment/AdditionAssignmentRootNodeTest.java
+++ b/src/test/java/tamir/parser/assignment/AdditionAssignmentRootNodeTest.java
@@ -7,32 +7,46 @@ import tamir.exception.UnknownVariableException;
 import tamir.parser.ast.IntegerAstNode;
 import tamir.parser.ast.VariableAstNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AdditionAssignmentRootNodeTest {
 
-	private IntegerAstNode integer;
+	private IntegerAstNode one;
 	private VariableAstNode variableX;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer = new IntegerAstNode(1);
+		one = new IntegerAstNode(1);
 		variableX = new VariableAstNode("x");
 		context = new CalculatorContext();
 		context.put("x", 3);
 	}
 
 	@Test
-	void whenAdditionAssigningExistingVariable_thenVariableIsBeingUpdatedInTheContext() {
-		new AdditionAssignmentRootNode("x", integer).execute(context);
+	void whenAdditionAssigningExistingVariable_thenVariableValueIsBeingUpdatedInTheContext() {
+		new AdditionAssignmentRootNode("x", one).execute(context);
 		assertEquals(4, variableX.interpret(context));
 	}
 
 	@Test
 	void whenAdditionAssigningOfUnknownVariable_thenInterpretThrowsUnknownVariableException() {
 		assertThrows(UnknownVariableException.class,
-				() -> new AdditionAssignmentRootNode("unknown", integer).execute(context));
+				() -> new AdditionAssignmentRootNode("unknown", one).execute(context));
+	}
+
+	@Test
+	void whenAdditionAssigningZeroToExistingVariable_thenVariableValueDoesNotChange() {
+		int xValueBeforeChange = variableX.interpret(context);
+		new AdditionAssignmentRootNode("x", new IntegerAstNode(0)).execute(context);
+		assertEquals(xValueBeforeChange, variableX.interpret(context));
+	}
+
+	@Test
+	void whenAdditionAssigningNegativeInteger_thenVariableValueHasBeenDecreased() {
+		int xValueBeforeChange = variableX.interpret(context);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new AdditionAssignmentRootNode("x", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) < xValueBeforeChange);
 	}
 }

--- a/src/test/java/tamir/parser/assignment/AssignmentRootNodeTest.java
+++ b/src/test/java/tamir/parser/assignment/AssignmentRootNodeTest.java
@@ -11,13 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AssignmentRootNodeTest {
 
-	private IntegerAstNode integer;
+	private IntegerAstNode one;
 	private VariableAstNode variableX;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer = new IntegerAstNode(1);
+		one = new IntegerAstNode(1);
 		variableX = new VariableAstNode("x");
 		context = new CalculatorContext();
 		context.put("x", 3);
@@ -27,22 +27,21 @@ class AssignmentRootNodeTest {
 	void whenAssigningNewVariable_thenVariableIsBeingAddedToTheContext() {
 		CalculatorContext context = new CalculatorContext();
 		assertTrue(context.getVariableToValue().isEmpty());
-		new AssignmentRootNode("x", integer).execute(context);
-		assertEquals(integer.interpret(context), variableX.interpret(context));
+		new AssignmentRootNode("x", one).execute(context);
+		assertEquals(one.interpret(context), variableX.interpret(context));
 	}
 
 	@Test
-	void whenAssigningExistingVariable_thenVariableIsBeingUpdatedInTheContext() {
-		new AssignmentRootNode("x", integer).execute(context);
-		assertEquals(integer.interpret(context), variableX.interpret(context));
+	void whenAssigningExistingVariable_thenVariableValueIsBeingUpdatedInTheContext() {
+		assertTrue(context.getVariableToValue().containsKey("x"));
+		new AssignmentRootNode("x", one).execute(context);
+		assertEquals(one.interpret(context), variableX.interpret(context));
 	}
 
 	@Test
 	void whenAssigningVariable_thenInterpretDoesNotChangeOtherVariablesInTheContext() {
-		VariableAstNode newVariable = new VariableAstNode("new");
-		new AssignmentRootNode("new", integer).execute(context);
-		int value = newVariable.interpret(context);
-		new AssignmentRootNode("x", integer).execute(context);
-		assertEquals(value, newVariable.interpret(context));
+		int xValueBeforeOperation = variableX.interpret(context);
+		new AssignmentRootNode("new", one).execute(context);
+		assertEquals(xValueBeforeOperation, variableX.interpret(context));
 	}
 }

--- a/src/test/java/tamir/parser/assignment/DivisionAssignmentRootNodeTest.java
+++ b/src/test/java/tamir/parser/assignment/DivisionAssignmentRootNodeTest.java
@@ -7,32 +7,60 @@ import tamir.exception.UnknownVariableException;
 import tamir.parser.ast.IntegerAstNode;
 import tamir.parser.ast.VariableAstNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DivisionAssignmentRootNodeTest {
 
-	private IntegerAstNode integer;
+	private IntegerAstNode two;
 	private VariableAstNode variableX;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer = new IntegerAstNode(2);
+		two = new IntegerAstNode(2);
 		variableX = new VariableAstNode("x");
 		context = new CalculatorContext();
 		context.put("x", 4);
 	}
 
 	@Test
-	void whenDivisionAssigningExistingVariable_thenVariableIsBeingUpdatedInTheContext() {
-		new DivisionAssignmentRootNode("x", integer).execute(context);
+	void whenDivisionAssigningExistingVariable_thenVariableValueIsBeingUpdatedInTheContext() {
+		new DivisionAssignmentRootNode("x", two).execute(context);
 		assertEquals(2, variableX.interpret(context));
 	}
 
 	@Test
 	void whenDivisionAssigningOfUnknownVariable_thenInterpretThrowsUnknownVariableException() {
 		assertThrows(UnknownVariableException.class,
-				() -> new DivisionAssignmentRootNode("unknown", integer).execute(context));
+				() -> new DivisionAssignmentRootNode("unknown", two).execute(context));
+	}
+
+	@Test
+	void whenDivisionAssigningByOne_thenVariableValueDoesNotChange() {
+		int xValueBeforeChange = variableX.interpret(context);
+		new DivisionAssignmentRootNode("x", new IntegerAstNode(1)).execute(context);
+		assertEquals(xValueBeforeChange, variableX.interpret(context));
+	}
+
+	@Test
+	void whenDivisionAssigningByZero_thenThrowsArithmeticException() {
+		assertThrows(ArithmeticException.class,
+				() -> new DivisionAssignmentRootNode("x", new IntegerAstNode(0)).execute(context));
+	}
+
+	@Test
+	void whenDivisionAssigningPositiveVariableByNegativeInteger_thenVariableValueIsNegative() {
+		assertTrue(variableX.interpret(context) > 0);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new DivisionAssignmentRootNode("x", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) < 0);
+	}
+
+	@Test
+	void whenDivisionAssigningNegativeVariableByNegativeInteger_thenVariableValueIsPositive() {
+		context.put("y", -1);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new DivisionAssignmentRootNode("y", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) > 0);
 	}
 }

--- a/src/test/java/tamir/parser/assignment/MultiplicationAssignmentRootNodeTest.java
+++ b/src/test/java/tamir/parser/assignment/MultiplicationAssignmentRootNodeTest.java
@@ -7,32 +7,60 @@ import tamir.exception.UnknownVariableException;
 import tamir.parser.ast.IntegerAstNode;
 import tamir.parser.ast.VariableAstNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MultiplicationAssignmentRootNodeTest {
 
-	private IntegerAstNode integer;
+	private IntegerAstNode five;
 	private VariableAstNode variableX;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer = new IntegerAstNode(5);
+		five = new IntegerAstNode(5);
 		variableX = new VariableAstNode("x");
 		context = new CalculatorContext();
 		context.put("x", 3);
 	}
 
 	@Test
-	void whenMultiplicationAssigningExistingVariable_thenVariableIsBeingUpdatedInTheContext() {
-		new MultiplicationAssignmentRootNode("x", integer).execute(context);
+	void whenMultiplicationAssigningExistingVariable_thenVariableValueIsBeingUpdatedInTheContext() {
+		new MultiplicationAssignmentRootNode("x", five).execute(context);
 		assertEquals(15, variableX.interpret(context));
 	}
 
 	@Test
 	void whenMultiplicationAssigningOfUnknownVariable_thenInterpretThrowsUnknownVariableException() {
 		assertThrows(UnknownVariableException.class,
-				() -> new MultiplicationAssignmentRootNode("unknown", integer).execute(context));
+				() -> new MultiplicationAssignmentRootNode("unknown", five).execute(context));
+	}
+
+	@Test
+	void whenMultiplicationAssigningByOne_thenVariableValueDoesNotChange() {
+		int xValueBeforeChange = variableX.interpret(context);
+		new MultiplicationAssignmentRootNode("x", new IntegerAstNode(1)).execute(context);
+		assertEquals(xValueBeforeChange, variableX.interpret(context));
+	}
+
+	@Test
+	void whenMultiplicationAssigningByZero_thenVariableIsSetToZero() {
+		new MultiplicationAssignmentRootNode("x", new IntegerAstNode(0)).execute(context);
+		assertEquals(0, variableX.interpret(context));
+	}
+
+	@Test
+	void whenMultiplicationAssigningPositiveVariableByNegativeInteger_thenVariableValueIsNegative() {
+		assertTrue(variableX.interpret(context) > 0);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new MultiplicationAssignmentRootNode("x", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) < 0);
+	}
+
+	@Test
+	void whenMultiplicationAssigningNegativeVariableByNegativeInteger_thenVariableValueIsPositive() {
+		context.put("y", -1);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new MultiplicationAssignmentRootNode("y", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) > 0);
 	}
 }

--- a/src/test/java/tamir/parser/assignment/SubtractionAssignmentRootNodeTest.java
+++ b/src/test/java/tamir/parser/assignment/SubtractionAssignmentRootNodeTest.java
@@ -7,18 +7,17 @@ import tamir.exception.UnknownVariableException;
 import tamir.parser.ast.IntegerAstNode;
 import tamir.parser.ast.VariableAstNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class SubtractionAssignmentRootNodeTest {
 
-	private IntegerAstNode integer;
+	private IntegerAstNode one;
 	private VariableAstNode variableX;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer = new IntegerAstNode(1);
+		one = new IntegerAstNode(1);
 		variableX = new VariableAstNode("x");
 		context = new CalculatorContext();
 		context.put("x", 3);
@@ -26,13 +25,34 @@ class SubtractionAssignmentRootNodeTest {
 
 	@Test
 	void whenSubtractionAssigningExistingVariable_thenVariableIsBeingUpdatedInTheContext() {
-		new SubtractionAssignmentRootNode("x", integer).execute(context);
+		new SubtractionAssignmentRootNode("x", one).execute(context);
 		assertEquals(2, variableX.interpret(context));
 	}
 
 	@Test
 	void whenSubtractionAssigningOfUnknownVariable_thenInterpretThrowsUnknownVariableException() {
 		assertThrows(UnknownVariableException.class,
-				() -> new SubtractionAssignmentRootNode("unknown", integer).execute(context));
+				() -> new SubtractionAssignmentRootNode("unknown", one).execute(context));
+	}
+
+	@Test
+	void whenSubtractionAssigningZero_thenVariableValueDoesNotChange() {
+		int xValueBeforeChange = variableX.interpret(context);
+		new SubtractionAssignmentRootNode("x", new IntegerAstNode(0)).execute(context);
+		assertEquals(xValueBeforeChange, variableX.interpret(context));
+	}
+
+	@Test
+	void whenSubtractionAssigningByVariablesValue_thenVariableEqualsZero() {
+		new SubtractionAssignmentRootNode("x", variableX).execute(context);
+		assertEquals(0, variableX.interpret(context));
+	}
+
+	@Test
+	void whenSubtractionAssigningByNegativeInteger_thenVariableValueHasBeenIncreased() {
+		int xValueBeforeChange = variableX.interpret(context);
+		IntegerAstNode negativeInteger = new IntegerAstNode(-1);
+		new SubtractionAssignmentRootNode("x", negativeInteger).execute(context);
+		assertTrue(variableX.interpret(context) > xValueBeforeChange);
 	}
 }

--- a/src/test/java/tamir/parser/ast/AbstractSyntaxTreeNodeTest.java
+++ b/src/test/java/tamir/parser/ast/AbstractSyntaxTreeNodeTest.java
@@ -8,12 +8,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AbstractSyntaxTreeNodeTest {
 
+	private IntegerAstNode four;
+	private IntegerAstNode six;
 	private VariableAstNode variableX;
 	private VariableAstNode variableY;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
+		four = new IntegerAstNode(4);
+		six = new IntegerAstNode(6);
 		variableX = new VariableAstNode("x");
 		variableY = new VariableAstNode("y");
 		context = new CalculatorContext();
@@ -28,13 +32,13 @@ class AbstractSyntaxTreeNodeTest {
 
 	@Test
 	void whenAstHasCompositeOperationsOnIntegers_thenReturnValue() {
-		assertEquals(24, new MultiplicationAstNode(variableX, new MultiplicationAstNode(variableX, variableY)).interpret(context));
+		assertEquals(96, new MultiplicationAstNode(four, new MultiplicationAstNode(four, six)).interpret(context));
 	}
 
 	@Test
 	void whenAstContainsPreIncrementAndDecrementOnSameVariable_thenVariableValueStaysTheSame() {
-		int xValue = variableX.interpret(context);
+		int xValueBeforeChange = variableX.interpret(context);
 		new AdditionAstNode(new PreIncrementAstNode("x"), new PreDecrementAstNode("x"));
-		assertEquals(xValue, variableX.interpret(context));
+		assertEquals(xValueBeforeChange, variableX.interpret(context));
 	}
 }

--- a/src/test/java/tamir/parser/ast/AdditionAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/AdditionAstNodeTest.java
@@ -5,19 +5,20 @@ import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AdditionAstNodeTest {
 
-	private IntegerAstNode integer1;
-	private IntegerAstNode integer2;
+	private IntegerAstNode one;
+	private IntegerAstNode two;
 	private VariableAstNode variableX;
 	private VariableAstNode variableY;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer1 = new IntegerAstNode(1);
-		integer2 = new IntegerAstNode(2);
+		one = new IntegerAstNode(1);
+		two = new IntegerAstNode(2);
 		variableX = new VariableAstNode("x");
 		variableY = new VariableAstNode("y");
 		context = new CalculatorContext();
@@ -32,23 +33,41 @@ class AdditionAstNodeTest {
 
 	@Test
 	void whenAddingTwoIntegers_thenInterpretToSumOfValues() {
-		assertEquals(3, new AdditionAstNode(integer1, integer2).interpret(context));
+		assertEquals(3, new AdditionAstNode(one, two).interpret(context));
 	}
 
 	@Test
 	void whenAddingIntegerAndVariable_thenInterpretToSumOfValues() {
-		assertEquals(4, new AdditionAstNode(integer1, variableX).interpret(context));
+		assertEquals(4, new AdditionAstNode(one, variableX).interpret(context));
 	}
 
 	@Test
 	void whenAddingVariableAndInteger_thenInterpretToSumOfValues() {
-		assertEquals(7, new AdditionAstNode(variableY, integer2).interpret(context));
+		assertEquals(7, new AdditionAstNode(variableY, two).interpret(context));
 	}
 
 	@Test
 	void testAdditionIsCommutative() {
-		int variableWithInteger = new AdditionAstNode(variableY, integer2).interpret(context);
-		int integerWithVariable = new AdditionAstNode(integer2, variableY).interpret(context);
+		int variableWithInteger = new AdditionAstNode(variableY, two).interpret(context);
+		int integerWithVariable = new AdditionAstNode(two, variableY).interpret(context);
 		assertEquals(variableWithInteger, integerWithVariable);
+	}
+
+	@Test
+	void whenAddingZeroToVariable_thenSumEqualsToVariableValue() {
+		IntegerAstNode zero = new IntegerAstNode(0);
+		assertEquals(variableX.interpret(context), new AdditionAstNode(zero, variableX).interpret(context));
+	}
+
+	@Test
+	void whenAddingTwoPositiveNumber_thenInterpretReturnsPositiveNumber() {
+		assertTrue(new AdditionAstNode(one, two).interpret(context) > 0);
+	}
+
+	@Test
+	void whenAddingTwoNegativeNumbers_thenInterpretReturnsNegativeNumber() {
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		IntegerAstNode minusTwo = new IntegerAstNode(-2);
+		assertTrue(new AdditionAstNode(minusOne, minusTwo).interpret(context) < 0);
 	}
 }

--- a/src/test/java/tamir/parser/ast/DivisionAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/DivisionAstNodeTest.java
@@ -4,21 +4,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DivisionAstNodeTest {
 
-	private IntegerAstNode integer1;
-	private IntegerAstNode integer2;
+	private IntegerAstNode one;
+	private IntegerAstNode twelve;
 	private VariableAstNode variableX;
 	private VariableAstNode variableY;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer1 = new IntegerAstNode(1);
-		integer2 = new IntegerAstNode(12);
+		one = new IntegerAstNode(1);
+		twelve = new IntegerAstNode(12);
 		variableX = new VariableAstNode("x");
 		variableY = new VariableAstNode("y");
 		context = new CalculatorContext();
@@ -33,26 +32,50 @@ class DivisionAstNodeTest {
 
 	@Test
 	void whenDividingTwoIntegers_thenInterpretReturnsDivisionProduct() {
-		assertEquals(12, new DivisionAstNode(integer2, integer1).interpret(context));
+		assertEquals(12, new DivisionAstNode(twelve, one).interpret(context));
 	}
 
 	@Test
 	void whenDividingVariableByInteger_thenInterpretReturnsDivisionProduct() {
-		assertEquals(6, new DivisionAstNode(variableY, integer1).interpret(context));
+		assertEquals(6, new DivisionAstNode(variableY, one).interpret(context));
 	}
 
 	@Test
 	void whenDividingIntegerByVariable_thenInterpretReturnsDivisionProduct() {
-		assertEquals(2, new DivisionAstNode(integer2, variableY).interpret(context));
+		assertEquals(2, new DivisionAstNode(twelve, variableY).interpret(context));
 	}
 
 	@Test
 	void whenDividingByZero_thenInterpretThrowsArithmeticException() {
-		assertThrows(ArithmeticException.class, () -> new DivisionAstNode(integer2, new IntegerAstNode(0)).interpret(context));
+		IntegerAstNode zero = new IntegerAstNode(0);
+		assertThrows(ArithmeticException.class, () -> new DivisionAstNode(twelve, zero).interpret(context));
 	}
 
 	@Test
-	void whenDividingTwoIntegersWithRemainder_thenInterpretReturnIntegerWithoutRemainder() {
-		assertEquals(0, new DivisionAstNode(variableY, integer2).interpret(context));
+	void whenDividingTwoIntegersWithRemainder_thenInterpretReturnsIntegerWithoutRemainder() {
+		assertEquals(0, new DivisionAstNode(variableY, twelve).interpret(context));
+	}
+
+	@Test
+	void whenDividingNumberByItself_thenInterpretReturnsOne() {
+		assertEquals(1, new DivisionAstNode(twelve, twelve).interpret(context));
+	}
+
+	@Test
+	void whenDividingPositiveNumberByPositiveNumber_thenInterpretReturnsPositiveNumber() {
+		assertTrue(0 < new DivisionAstNode(twelve, one).interpret(context));
+	}
+
+	@Test
+	void whenDividingPositiveNumberByNegativeNumber_thenInterpretReturnsNegativeNumber() {
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		assertTrue(0 > new DivisionAstNode(twelve, minusOne).interpret(context));
+	}
+
+	@Test
+	void whenDividingNegativeNumberByNegativeNumber_thenInterpretReturnsPositiveNumber() {
+		IntegerAstNode minusTen = new IntegerAstNode(-10);
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		assertTrue(0 < new DivisionAstNode(minusTen, minusOne).interpret(context));
 	}
 }

--- a/src/test/java/tamir/parser/ast/MultiplicationAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/MultiplicationAstNodeTest.java
@@ -5,18 +5,19 @@ import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MultiplicationAstNodeTest {
-	private IntegerAstNode integer1;
-	private IntegerAstNode integer2;
+	private IntegerAstNode two;
+	private IntegerAstNode three;
 	private VariableAstNode variableX;
 	private VariableAstNode variableY;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer1 = new IntegerAstNode(2);
-		integer2 = new IntegerAstNode(3);
+		two = new IntegerAstNode(2);
+		three = new IntegerAstNode(3);
 		variableX = new VariableAstNode("x");
 		variableY = new VariableAstNode("y");
 		context = new CalculatorContext();
@@ -31,37 +32,57 @@ class MultiplicationAstNodeTest {
 
 	@Test
 	void whenMultiplyingTwoIntegers_thenInterpretReturnsMultiplicationProduct() {
-		assertEquals(6, new MultiplicationAstNode(integer1, integer2).interpret(context));
+		assertEquals(6, new MultiplicationAstNode(two, three).interpret(context));
 	}
 
 	@Test
 	void whenMultiplyingVariableByInteger_thenInterpretReturnsMultiplicationProduct() {
-		assertEquals(8, new MultiplicationAstNode(variableY, integer1).interpret(context));
+		assertEquals(8, new MultiplicationAstNode(variableY, two).interpret(context));
 	}
 
 	@Test
 	void whenMultiplyingIntegerByVariable_thenInterpretReturnsMultiplicationProduct() {
-		assertEquals(12, new MultiplicationAstNode(integer2, variableY).interpret(context));
+		assertEquals(12, new MultiplicationAstNode(three, variableY).interpret(context));
 	}
 
 	@Test
 	void testMultiplicationIsCommutative() {
-		int integer1ByInteger2 = new MultiplicationAstNode(integer1, integer2).interpret(context);
-		int integer2ByInteger1 = new MultiplicationAstNode(integer2, integer1).interpret(context);
-		assertEquals(integer1ByInteger2, integer2ByInteger1);
+		int twoByThree = new MultiplicationAstNode(two, three).interpret(context);
+		int threeByTwo = new MultiplicationAstNode(three, two).interpret(context);
+		assertEquals(twoByThree, threeByTwo);
 	}
 
 	@Test
-	void whenMultiplyingByOne_thenInterpretReturnsSecondValue() {
-		assertEquals(integer1.interpret(context), new MultiplicationAstNode(new IntegerAstNode(1), integer1).interpret(context));
-		assertEquals(integer2.interpret(context), new MultiplicationAstNode(new IntegerAstNode(1), integer2).interpret(context));
-		assertEquals(variableY.interpret(context), new MultiplicationAstNode(new IntegerAstNode(1), variableY).interpret(context));
+	void whenMultiplyingByOne_thenInterpretReturnsOtherOperandValue() {
+		IntegerAstNode one = new IntegerAstNode(1);
+		assertEquals(two.interpret(context), new MultiplicationAstNode(one, two).interpret(context));
+		assertEquals(three.interpret(context), new MultiplicationAstNode(one, three).interpret(context));
+		assertEquals(variableY.interpret(context), new MultiplicationAstNode(one, variableY).interpret(context));
 	}
 
 	@Test
 	void whenMultiplyingByZero_thenReturnZero() {
-		assertEquals(0, new MultiplicationAstNode(new IntegerAstNode(0), integer1).interpret(context));
-		assertEquals(0, new MultiplicationAstNode(new IntegerAstNode(0), integer2).interpret(context));
-		assertEquals(0, new MultiplicationAstNode(new IntegerAstNode(0), variableY).interpret(context));
+		IntegerAstNode zero = new IntegerAstNode(0);
+		assertEquals(0, new MultiplicationAstNode(zero, two).interpret(context));
+		assertEquals(0, new MultiplicationAstNode(zero, three).interpret(context));
+		assertEquals(0, new MultiplicationAstNode(zero, variableY).interpret(context));
+	}
+
+	@Test
+	void whenMultiplyingPositiveNumberByPositiveNumber_thenInterpretReturnsPositiveNumber() {
+		assertTrue(0 < new MultiplicationAstNode(two, three).interpret(context));
+	}
+
+	@Test
+	void whenMultiplyingPositiveNumberByNegativeNumber_thenInterpretReturnsNegativeNumber() {
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		assertTrue(0 > new MultiplicationAstNode(two, minusOne).interpret(context));
+	}
+
+	@Test
+	void whenMultiplyingNegativeNumberByNegativeNumber_thenInterpretReturnsPositiveNumber() {
+		IntegerAstNode minusTen = new IntegerAstNode(-10);
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		assertTrue(0 < new MultiplicationAstNode(minusTen, minusOne).interpret(context));
 	}
 }

--- a/src/test/java/tamir/parser/ast/PostDecrementAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/PostDecrementAstNodeTest.java
@@ -3,8 +3,10 @@ package tamir.parser.ast;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
+import tamir.exception.UnknownVariableException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostDecrementAstNodeTest {
 
@@ -22,12 +24,17 @@ class PostDecrementAstNodeTest {
 	}
 
 	@Test
+	void whenPostDecrementUnknownVariable_thenInterpretThrowsUnknownVariableException() {
+		assertThrows(UnknownVariableException.class, () -> new PostDecrementAstNode("unknown").interpret(context));
+	}
+
+	@Test
 	void whenPostDecrementOfVariable_thenInterpretReturnsValueBeforeDecrement() {
 		assertEquals(0, new PostDecrementAstNode("x").interpret(context));
 	}
 
 	@Test
-	void whenPostDecrementOfVariable_thenInterpretUpdatesVariableInContextToMinusOne() {
+	void whenPostDecrementOfVariable_thenInterpretUpdatesVariableInContextByMinusOne() {
 		int xValueBeforePostDecrement = variableX.interpret(context);
 		new PostDecrementAstNode("x").interpret(context);
 		assertEquals(xValueBeforePostDecrement - 1, variableX.interpret(context));

--- a/src/test/java/tamir/parser/ast/PostIncrementAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/PostIncrementAstNodeTest.java
@@ -3,8 +3,10 @@ package tamir.parser.ast;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
+import tamir.exception.UnknownVariableException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PostIncrementAstNodeTest {
 
@@ -22,12 +24,17 @@ class PostIncrementAstNodeTest {
 	}
 
 	@Test
+	void whenPostIncrementUnknownVariable_thenInterpretThrowsUnknownVariableException() {
+		assertThrows(UnknownVariableException.class, () -> new PostIncrementAstNode("unknown").interpret(context));
+	}
+
+	@Test
 	void whenPostIncrementOfVariable_thenInterpretReturnsValueBeforeIncrement() {
 		assertEquals(2, new PostIncrementAstNode("x").interpret(context));
 	}
 
 	@Test
-	void whenPostIncrementOfVariable_thenInterpretUpdatesVariableInContextToPlusOne() {
+	void whenPostIncrementOfVariable_thenInterpretUpdatesVariableInContextByPlusOne() {
 		int xValueBeforePostIncrement = variableX.interpret(context);
 		new PostIncrementAstNode("x").interpret(context);
 		assertEquals(xValueBeforePostIncrement + 1, variableX.interpret(context));

--- a/src/test/java/tamir/parser/ast/PreDecrementAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/PreDecrementAstNodeTest.java
@@ -3,8 +3,10 @@ package tamir.parser.ast;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
+import tamir.exception.UnknownVariableException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PreDecrementAstNodeTest {
 
@@ -22,12 +24,17 @@ class PreDecrementAstNodeTest {
 	}
 
 	@Test
+	void whenPreDecrementUnknownVariable_thenInterpretThrowsUnknownVariableException() {
+		assertThrows(UnknownVariableException.class, () -> new PreDecrementAstNode("unknown").interpret(context));
+	}
+
+	@Test
 	void whenPreDecrementOfVariable_thenInterpretReturnsValueAfterDecrement() {
 		assertEquals(4, new PreDecrementAstNode("x").interpret(context));
 	}
 
 	@Test
-	void whenPreDecrementOfVariable_thenInterpretUpdatesVariableInContextToMinusOne() {
+	void whenPreDecrementOfVariable_thenInterpretUpdatesVariableInContextByMinusOne() {
 		int xValueBeforePreDecrement = variableX.interpret(context);
 		new PreDecrementAstNode("x").interpret(context);
 		assertEquals(xValueBeforePreDecrement - 1, variableX.interpret(context));

--- a/src/test/java/tamir/parser/ast/PreIncrementAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/PreIncrementAstNodeTest.java
@@ -3,8 +3,10 @@ package tamir.parser.ast;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
+import tamir.exception.UnknownVariableException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PreIncrementAstNodeTest {
 
@@ -22,12 +24,17 @@ class PreIncrementAstNodeTest {
 	}
 
 	@Test
+	void whenPreIncrementUnknownVariable_thenInterpretThrowsUnknownVariableException() {
+		assertThrows(UnknownVariableException.class, () -> new PreIncrementAstNode("unknown").interpret(context));
+	}
+
+	@Test
 	void whenPreIncrementOfVariable_thenInterpretReturnsValueAfterIncrement() {
 		assertEquals(45, new PreIncrementAstNode("x").interpret(context));
 	}
 
 	@Test
-	void whenPreIncrementOfVariable_thenInterpretUpdatesVariableInContextToPlusOne() {
+	void whenPreIncrementOfVariable_thenInterpretUpdatesVariableInContextByPlusOne() {
 		int xValueBeforePreIncrement = variableX.interpret(context);
 		new PreIncrementAstNode("x").interpret(context);
 		assertEquals(xValueBeforePreIncrement + 1, variableX.interpret(context));

--- a/src/test/java/tamir/parser/ast/SubtractionAstNodeTest.java
+++ b/src/test/java/tamir/parser/ast/SubtractionAstNodeTest.java
@@ -5,19 +5,20 @@ import org.junit.jupiter.api.Test;
 import tamir.calculator.CalculatorContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SubtractionAstNodeTest {
 
-	private IntegerAstNode integer1;
-	private IntegerAstNode integer2;
+	private IntegerAstNode one;
+	private IntegerAstNode two;
 	private VariableAstNode variableX;
 	private VariableAstNode variableY;
 	private CalculatorContext context;
 
 	@BeforeEach
 	void setup() {
-		integer1 = new IntegerAstNode(1);
-		integer2 = new IntegerAstNode(2);
+		one = new IntegerAstNode(1);
+		two = new IntegerAstNode(2);
 		variableX = new VariableAstNode("x");
 		variableY = new VariableAstNode("y");
 		context = new CalculatorContext();
@@ -32,16 +33,35 @@ class SubtractionAstNodeTest {
 
 	@Test
 	void whenSubtractingTwoIntegers_thenInterpretToDifferenceOfValues() {
-		assertEquals(-1, new SubtractionAstNode(integer1, integer2).interpret(context));
+		assertEquals(-1, new SubtractionAstNode(one, two).interpret(context));
 	}
 
 	@Test
 	void whenSubtractingIntegerAndVariable_thenInterpretToDifferenceOfValues() {
-		assertEquals(-2, new SubtractionAstNode(integer1, variableX).interpret(context));
+		assertEquals(-2, new SubtractionAstNode(one, variableX).interpret(context));
 	}
 
 	@Test
 	void whenSubtractingVariableAndInteger_thenInterpretToDifferenceOfValues() {
-		assertEquals(3, new SubtractionAstNode(variableY, integer2).interpret(context));
+		assertEquals(3, new SubtractionAstNode(variableY, two).interpret(context));
+	}
+
+	@Test
+	void whenSubtractingZeroFromValue_thenInterpretReturnValueWithoutChange() {
+		IntegerAstNode zero = new IntegerAstNode(0);
+		assertEquals(1, new SubtractionAstNode(one, zero).interpret(context));
+	}
+
+	@Test
+	void whenSubtractingPositiveNumberFromValue_thenValueHasBeenDecreased() {
+		int xValueBeforeChange = variableX.interpret(context);
+		assertTrue(xValueBeforeChange > new SubtractionAstNode(variableX, one).interpret(context));
+	}
+
+	@Test
+	void whenSubtractingNegativeNumberFromValue_thenValueHasBeenIncreased() {
+		int xValueBeforeChange = variableX.interpret(context);
+		IntegerAstNode minusOne = new IntegerAstNode(-1);
+		assertTrue(xValueBeforeChange < new SubtractionAstNode(variableX, minusOne).interpret(context));
 	}
 }


### PR DESCRIPTION
Refactored names to make tests more readable.
Add more test cases.
Fixed invalid AST parsing which caused error for operators of same precedence, for example - x = 1 - 2 - 3, which resulted with 2 instead of -4.